### PR TITLE
Golangの設計思想に合わせてクリーンアーキテクチャを変更した

### DIFF
--- a/src/di/hook.go
+++ b/src/di/hook.go
@@ -7,6 +7,7 @@
 package di
 
 import (
+	"github.com/gofiber/fiber/v2"
 	"github.com/kouhei-github/golang-ddd-boboilerplate/handler"
 	"github.com/kouhei-github/golang-ddd-boboilerplate/repository"
 	"github.com/kouhei-github/golang-ddd-boboilerplate/router"
@@ -14,7 +15,11 @@ import (
 	"gorm.io/gorm"
 )
 
-func NewRouter(db gorm.DB) router.Router {
+type Router interface {
+	Register(c fiber.Router)
+}
+
+func NewRouter(db gorm.DB) Router {
 	hellowWorld := repository.NewHelloWorldRepository(db)
 	helloWorldService := service.NewHelloWorldService(hellowWorld)
 	helloWorldHandler := handler.NewHelloWorldHandler(helloWorldService)

--- a/src/handler/hello_world.go
+++ b/src/handler/hello_world.go
@@ -3,28 +3,28 @@ package handler
 import (
 	"fmt"
 	"github.com/gofiber/fiber/v2"
-	"github.com/kouhei-github/golang-ddd-boboilerplate/service"
 	"strconv"
 	"strings"
 )
 
-type HelloWorldHandler interface {
-	HelloWorld(c *fiber.Ctx) error
+type IHelloWorldService interface {
+	HelloMessage(id int) string
+	WorldMessage(id int, userID int) string
 }
 
-type helloWorld struct {
-	serviceHelloWorld service.HelloWorldService
+type HelloWorldHandler struct {
+	serviceHelloWorld IHelloWorldService
 }
 
 func NewHelloWorldHandler(
-	serviceHelloWorld service.HelloWorldService,
-) HelloWorldHandler {
-	return &helloWorld{
+	serviceHelloWorld IHelloWorldService,
+) *HelloWorldHandler {
+	return &HelloWorldHandler{
 		serviceHelloWorld: serviceHelloWorld,
 	}
 }
 
-func (h *helloWorld) HelloWorld(c *fiber.Ctx) error {
+func (h *HelloWorldHandler) HelloWorld(c *fiber.Ctx) error {
 	query := c.Query("id")
 	userId, err := strconv.Atoi(query)
 	if err != nil {

--- a/src/main.go
+++ b/src/main.go
@@ -13,6 +13,7 @@ func main() {
 
 	database := provider.NewDatabaseProvider()
 	db, _, _ := database.Connect()
+	//db.AutoMigrate(&models.User{}) // auto migrationできる
 	if db == nil {
 		panic("db is nil.")
 	}

--- a/src/repository/hello_world.go
+++ b/src/repository/hello_world.go
@@ -4,27 +4,22 @@ import (
 	"gorm.io/gorm"
 )
 
-type HelloWorld interface {
-	GetHello(id int) (string, error)
-	GetWorld() string
-}
-
-type helloWorld struct {
+type HelloWorld struct {
 	db gorm.DB
 }
 
-func NewHelloWorldRepository(db gorm.DB) HelloWorld {
-	return &helloWorld{
+func NewHelloWorldRepository(db gorm.DB) *HelloWorld {
+	return &HelloWorld{
 		db: db,
 	}
 }
 
-func (c *helloWorld) GetHello(id int) (string, error) {
+func (c *HelloWorld) GetHello(id int) (string, error) {
 	hello := "World"
 	return hello, nil
 }
 
-func (c *helloWorld) GetWorld() string {
+func (c *HelloWorld) GetWorld() string {
 	world := "World"
 	return world
 }

--- a/src/router/router.go
+++ b/src/router/router.go
@@ -2,26 +2,25 @@ package router
 
 import (
 	"github.com/gofiber/fiber/v2"
-	"github.com/kouhei-github/golang-ddd-boboilerplate/handler"
 )
 
-type Router interface {
-	Register(c fiber.Router)
+type IHelloWorldHandler interface {
+	HelloWorld(c *fiber.Ctx) error
 }
 
-type router struct {
-	helloWorld handler.HelloWorldHandler
+type Router struct {
+	helloWorld IHelloWorldHandler
 }
 
 func NewRouter(
-	helloWorld handler.HelloWorldHandler,
-) Router {
-	return &router{
+	helloWorld IHelloWorldHandler,
+) *Router {
+	return &Router{
 		helloWorld: helloWorld,
 	}
 }
 
-func (r router) Register(c fiber.Router) {
+func (r *Router) Register(c fiber.Router) {
 	common := c.Group("/api")
 	common.Get("/test", r.helloWorld.HelloWorld)
 }

--- a/src/service/hello_world.go
+++ b/src/service/hello_world.go
@@ -1,31 +1,27 @@
 package service
 
-import (
-	"github.com/kouhei-github/golang-ddd-boboilerplate/repository"
-)
-
-type HelloWorldService interface {
-	HelloMessage(id int) string
-	WorldMessage(id int, userID int) string
+type IHelloWorldRepository interface {
+	GetHello(id int) (string, error)
+	GetWorld() string
 }
 
-type helloWorldService struct {
-	repositoryHelloWorld repository.HelloWorld
+type HelloWorldService struct {
+	repositoryHelloWorld IHelloWorldRepository
 }
 
 func NewHelloWorldService(
-	repositoryHelloWorld repository.HelloWorld,
-) HelloWorldService {
-	return &helloWorldService{
+	repositoryHelloWorld IHelloWorldRepository,
+) *HelloWorldService {
+	return &HelloWorldService{
 		repositoryHelloWorld: repositoryHelloWorld,
 	}
 }
 
-func (c *helloWorldService) HelloMessage(tid int) string {
+func (c *HelloWorldService) HelloMessage(tid int) string {
 	msg, _ := c.repositoryHelloWorld.GetHello(tid)
 	return msg
 }
 
-func (c *helloWorldService) WorldMessage(id int, userID int) string {
+func (c *HelloWorldService) WorldMessage(id int, userID int) string {
 	return c.repositoryHelloWorld.GetWorld()
 }


### PR DESCRIPTION
# Golangの原則(インターフェースは使用する側で定義する)
・**インターフェイスを受け入れ、構造体を返す**
Accept interfaces, return structs

---

## 間違いな例
tcp.go
構造体をReturnするのではなく、インターフェースをReturnしている
これでは構造体のフィールドを活用できない。
```go
package tcp
type Server interface {
    Start()
}
type server struct { ... }
func (s *server) Start() { ... }
func NewServer() Server { return &server{ ... } }
```
consumer.go
```go
package consumer
import "tcp"
func StartServer(s tcp.Server) { s.Start() }
```

## 正しい例
戻り値は構造体で引数でInterfaceを受け取っている
tcp.go
```go
package tcp
type Server struct { ... }
func (s *Server) Start() { ... }
func NewServer() Server { return &Server{ ... } }
```
使用する側でインターフェースを使用する良い例
consumer.go
```go
package consumer
type Server interface {
    Start() 
}
func StartServer(s Server) { s.Start() }
```

---

## 実際に標準ライブラリーでも使用箇所でインターフェースを定義している
### ioパッケージ
```go
type Reader interface {
    Read(p []byte) (n int, err error)
}
func Copy(dst Writer, src Reader) (written int64, err error)
```

### httpパッケージ
```go
type Handler interface { 
    ServeHTTP(ResponseWriter, *Request) 
} 
func ListenAndServe(addr string, handler Handler) error
```

## 参考文献
[https://medium.com/@mbinjamil/using-interfaces-in-go-the-right-way-99384bc69d39](https://medium.com/@mbinjamil/using-interfaces-in-go-the-right-way-99384bc69d39)
[https://zenn.dev/pranc1ngpegasus/articles/a8c92235bec641](https://zenn.dev/pranc1ngpegasus/articles/a8c92235bec641)

